### PR TITLE
Simulate custom model

### DIFF
--- a/src/app/app-interactive-map/services/simulation.service.ts
+++ b/src/app/app-interactive-map/services/simulation.service.ts
@@ -24,7 +24,7 @@ export class SimulationService {
     private http: HttpClient,
   ) {}
 
-  simulate(model: string, payload: SimulateRequest): Observable<DeCaF.Solution> {
-    return this.http.post<DeCaF.Solution>(`${environment.apis.model}/models/${model}/simulate`, payload);
+  simulate(payload: SimulateRequest): Observable<DeCaF.Solution> {
+    return this.http.post<DeCaF.Solution>(`${environment.apis.model}/simulate`, payload);
   }
 }

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -149,12 +149,14 @@ export class InteractiveMapEffects {
     withLatestFrom(this.store$.pipe(select((store) => store.interactiveMap.selectedModel))),
     switchMap(([{payload: type}, model]: [fromActions.AddCard, types.DeCaF.Model]) => {
       const payload: types.SimulateRequest = {
+        model: model.model_serialized,
+        biomass_reaction: model.default_biomass_reaction,
         method: 'fba',
         objective: null,
         objective_direction: null,
         operations: [],
       };
-      return this.simulationSerivce.simulate(model.name, payload)
+      return this.simulationSerivce.simulate(payload)
         .pipe(
           map((solution) => ({
             type,
@@ -254,6 +256,8 @@ export class InteractiveMapEffects {
       }));
 
       const payload: types.SimulateRequest = {
+        model: store.interactiveMap.selectedModel.model_serialized,
+        biomass_reaction: store.interactiveMap.selectedModel.default_biomass_reaction,
         method: selectedCard.method,
         objective_direction: selectedCard.objectiveReaction ? selectedCard.objectiveReaction.direction : null,
         objective: selectedCard.objectiveReaction ? selectedCard.objectiveReaction.reactionId : null,
@@ -263,7 +267,7 @@ export class InteractiveMapEffects {
           ...bounds,
         ],
       };
-      return this.http.post(`${environment.apis.model}/models/${store.interactiveMap.selectedModel.name}/simulate`, payload)
+      return this.http.post(`${environment.apis.model}/simulate`, payload)
         .pipe(map((solution: types.DeCaF.Solution) => ({
           action: newAction,
           solution,

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -267,7 +267,7 @@ export class InteractiveMapEffects {
           ...bounds,
         ],
       };
-      return this.http.post(`${environment.apis.model}/simulate`, payload)
+      return this.simulationSerivce.simulate(payload)
         .pipe(map((solution: types.DeCaF.Solution) => ({
           action: newAction,
           solution,

--- a/src/app/app-interactive-map/types.ts
+++ b/src/app/app-interactive-map/types.ts
@@ -204,6 +204,8 @@ export declare namespace DeCaF {
 }
 
 export interface SimulateRequest {
+  model: Cobra.Model;
+  biomass_reaction: string;
   method: Methods;
   objective?: string;
   objective_direction: ObjectiveDirection;


### PR DESCRIPTION
- Changes simulation endpoint and adds serialized model + biomass reaction to the request
- Use SimulationService, not manual http post