### PR TITLE
Handle new model-warehouse API

### DIFF
--- a/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
+++ b/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
@@ -50,8 +50,8 @@ export class AppFormDesignComponent implements OnInit, AfterViewInit {
 
   public products: Observable<typesDesign.Product[]>;
 
-  public selectedModel: Observable<types.DeCaF.Model>;
-  public models: Observable<types.DeCaF.Model[]>;
+  public selectedModel: Observable<types.DeCaF.ModelHeader>;
+  public models: Observable<types.DeCaF.ModelHeader[]>;
 
   constructor(
     private fb: FormBuilder,

--- a/src/app/app-design-tool/store/design-tool.actions.ts
+++ b/src/app/app-design-tool/store/design-tool.actions.ts
@@ -54,12 +54,12 @@ export class FetchModelsDesign implements Action {
 
 export class SetModelsDesign implements Action {
   readonly type = SET_MODELS_DESIGN;
-  constructor(public payload: types.DeCaF.Model[]) {}
+  constructor(public payload: types.DeCaF.ModelHeader[]) {}
 }
 
 export class SetModelDesign implements Action {
   readonly type = SET_MODEL_DESIGN;
-  constructor(public payload: types.DeCaF.Model) {}
+  constructor(public payload: types.DeCaF.ModelHeader) {}
 }
 
 export class FetchProductsDesign implements Action {

--- a/src/app/app-design-tool/store/design-tool.effects.ts
+++ b/src/app/app-design-tool/store/design-tool.effects.ts
@@ -54,7 +54,7 @@ export class DesignToolEffects {
     ofType(fromActions.FETCH_MODELS_DESIGN),
     switchMap(() =>
       this.modelService.loadModels()),
-    map((models: types.DeCaF.Model[]) => new fromActions.SetModelsDesign(models)),
+    map((models: types.DeCaF.ModelHeader[]) => new fromActions.SetModelsDesign(models)),
   );
 
   @Effect()

--- a/src/app/app-design-tool/store/design-tool.reducers.ts
+++ b/src/app/app-design-tool/store/design-tool.reducers.ts
@@ -20,8 +20,8 @@ import * as typesDesign from '../types';
 export interface DesignToolState {
   allSpecies: types.Species[];
   selectedSpecies: types.Species;
-  models: types.DeCaF.Model[];
-  selectedModel: types.DeCaF.Model;
+  models: types.DeCaF.ModelHeader[];
+  selectedModel: types.DeCaF.ModelHeader;
   products: typesDesign.Product[];
   designStarted: boolean;
   jobs: string[];

--- a/src/app/app-interactive-map/components/app-global-settings/app-global-settings.component.html
+++ b/src/app/app-interactive-map/components/app-global-settings/app-global-settings.component.html
@@ -20,8 +20,8 @@
   </mat-form-field>
 
   <mat-form-field>
-    <mat-select placeholder="Model" [value]="selectedModel | async" #model>
-      <mat-option [value]="model" *ngFor="let model of (models | async)">{{model.name}}</mat-option>
+    <mat-select placeholder="Model" [value]="selectedModelHeader | async" #model>
+      <mat-option [value]="model" *ngFor="let model of (activeModelHeaders | async)">{{model.name}}</mat-option>
     </mat-select>
   </mat-form-field>
 

--- a/src/app/app-interactive-map/components/app-global-settings/app-global-settings.component.ts
+++ b/src/app/app-interactive-map/components/app-global-settings/app-global-settings.component.ts
@@ -36,8 +36,8 @@ export class AppGlobalSettingsComponent implements OnInit, AfterViewInit {
   public selectedSpecies: Observable<types.Species>;
   public allSpecies: Observable<types.Species[]>;
 
-  public selectedModel: Observable<types.DeCaF.Model>;
-  public models: Observable<types.DeCaF.Model[]>;
+  public selectedModelHeader: Observable<types.DeCaF.ModelHeader>;
+  public activeModelHeaders: Observable<types.DeCaF.ModelHeader[]>;
 
   public selectedMap: Observable<types.MapItem>;
   public mapItems: Observable<{
@@ -51,8 +51,8 @@ export class AppGlobalSettingsComponent implements OnInit, AfterViewInit {
     this.selectedSpecies = this.store.pipe(select((store) => store.interactiveMap.selectedSpecies));
     this.allSpecies = this.store.pipe(select((store) => store.interactiveMap.allSpecies));
 
-    this.selectedModel = this.store.pipe(select((store) => store.interactiveMap.selectedModel));
-    this.models = this.store.pipe(select(activeModels));
+    this.selectedModelHeader = this.store.pipe(select((store) => store.interactiveMap.selectedModelHeader));
+    this.activeModelHeaders = this.store.pipe(select(activeModels));
 
     this.selectedMap = this.store.pipe(select((store) => store.interactiveMap.selectedMap));
     this.mapItems = this.store.pipe(select(mapItemsByModel));

--- a/src/app/app-interactive-map/store/interactive-map.actions.ts
+++ b/src/app/app-interactive-map/store/interactive-map.actions.ts
@@ -70,12 +70,12 @@ export class FetchModels implements Action {
 
 export class SetModels implements Action {
   readonly type = SET_MODELS;
-  constructor(public payload: types.DeCaF.Model[]) {}
+  constructor(public payload: types.DeCaF.ModelHeader[]) {}
 }
 
 export class SetModel implements Action {
   readonly type = SET_MODEL;
-  constructor(public payload: types.DeCaF.Model) {}
+  constructor(public payload: types.DeCaF.ModelHeader) {}
 }
 
 export class FetchMaps implements Action {

--- a/src/app/app-interactive-map/store/interactive-map.actions.ts
+++ b/src/app/app-interactive-map/store/interactive-map.actions.ts
@@ -23,6 +23,7 @@ export const SET_SELECTED_SPECIES = 'SET_SELECTED_SPECIES';
 export const FETCH_MODELS = 'FETCH_MODELS';
 export const SET_MODELS = 'SET_MODELS';
 export const SET_MODEL = 'SET_MODEL';
+export const SET_FULL_MODEL = 'SET_FULL_MODEL';
 
 export const FETCH_MAPS = 'FETCH_MAPS';
 export const SET_MAPS = 'SET_MAPS';
@@ -76,6 +77,11 @@ export class SetModels implements Action {
 export class SetModel implements Action {
   readonly type = SET_MODEL;
   constructor(public payload: types.DeCaF.ModelHeader) {}
+}
+
+export class SetFullModel implements Action {
+  readonly type = SET_FULL_MODEL;
+  constructor(public payload: types.DeCaF.Model) {}
 }
 
 export class FetchMaps implements Action {
@@ -188,6 +194,7 @@ export type InteractiveMapActions =
   SetSelectedSpecies |
   SetModels |
   SetModel |
+  SetFullModel |
   SetMaps |
   MapFetched |
   ResetCards |

--- a/src/app/app-interactive-map/store/interactive-map.actions.ts
+++ b/src/app/app-interactive-map/store/interactive-map.actions.ts
@@ -182,6 +182,22 @@ export const operationToApply = {
 };
 
 export type OperationAction = SetObjectiveReaction | ReactionOperation;
-export type InteractiveMapActions = FetchSpecies | SetSpecies | SetSelectedSpecies | SetModels | SetModel | SetMaps | MapFetched |
-  ResetCards | SelectCard | NextCard | PreviousCard | SetPlayState | AddCardFetched | DeleteCard | RenameCard |
-  SetMethodApply | ReactionOperationApply | SetObjectiveReactionApply;
+export type InteractiveMapActions =
+  FetchSpecies |
+  SetSpecies |
+  SetSelectedSpecies |
+  SetModels |
+  SetModel |
+  SetMaps |
+  MapFetched |
+  ResetCards |
+  SelectCard |
+  NextCard |
+  PreviousCard |
+  SetPlayState |
+  AddCardFetched |
+  DeleteCard |
+  RenameCard |
+  SetMethodApply |
+  ReactionOperationApply |
+  SetObjectiveReactionApply;

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -85,9 +85,9 @@ export class InteractiveMapEffects {
     this.actions$.pipe(ofType(fromActions.SET_MODELS)),
   ).pipe(
     map(([a, {payload: {id: selectedOrgId}}, {payload: models}]: [never, fromActions.SetSelectedSpecies, fromActions.SetModels]) => {
-      const selectedModel = models
+      const selectedModelHeader = models
         .filter((model) => model.organism_id === selectedOrgId.toString())[0];
-      return new fromActions.SetModel(selectedModel);
+      return new fromActions.SetModel(selectedModelHeader);
     }),
   );
 
@@ -130,11 +130,10 @@ export class InteractiveMapEffects {
   @Effect()
   simulateNewCard: Observable<Action> = this.actions$.pipe(
     ofType(fromActions.ADD_CARD),
-    withLatestFrom(this.store$.pipe(select((store) => store.interactiveMap.selectedModel))),
+    withLatestFrom(this.store$.pipe(select((store) => store.interactiveMap.selectedModelHeader))),
     switchMap(([{payload: type}, model]: [fromActions.AddCard, types.DeCaF.Model]) => {
       const payload: types.SimulateRequest = {
-        model: model.model_serialized,
-        biomass_reaction: model.default_biomass_reaction,
+        model_id: model.id,
         method: 'fba',
         objective: null,
         objective_direction: null,
@@ -240,8 +239,7 @@ export class InteractiveMapEffects {
       }));
 
       const payload: types.SimulateRequest = {
-        model: store.interactiveMap.selectedModel.model_serialized,
-        biomass_reaction: store.interactiveMap.selectedModel.default_biomass_reaction,
+        model_id: store.interactiveMap.selectedModelHeader.id,
         method: selectedCard.method,
         objective_direction: selectedCard.objectiveReaction ? selectedCard.objectiveReaction.direction : null,
         objective: selectedCard.objectiveReaction ? selectedCard.objectiveReaction.reactionId : null,

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -128,6 +128,14 @@ export class InteractiveMapEffects {
   );
 
   @Effect()
+  fetchFullModel: Observable<Action> = this.actions$.pipe(
+    ofType(fromActions.SET_MODEL),
+    switchMap((action: fromActions.SetFullModel) =>
+      this.http.get(`${environment.apis.model_warehouse}/models/${action.payload.id}`)),
+    map((model: types.DeCaF.Model) => new fromActions.SetFullModel(model)),
+  );
+
+  @Effect()
   simulateNewCard: Observable<Action> = this.actions$.pipe(
     ofType(fromActions.ADD_CARD),
     withLatestFrom(this.store$.pipe(select((store) => store.interactiveMap.selectedModelHeader))),

--- a/src/app/app-interactive-map/store/interactive-map.reducer.spec.ts
+++ b/src/app/app-interactive-map/store/interactive-map.reducer.spec.ts
@@ -34,17 +34,21 @@ const addedReaction: types.AddedReaction = {
   model_bigg_id: '',
 };
 
-const testModel: types.DeCaF.Model = {
-  created: 'now',
+const testModelHeader: types.DeCaF.ModelHeader = {
   id: 0,
   name: 'Foo',
+  organism_id: 'asd',
+};
+
+const testModel: types.DeCaF.Model = {
+  ...testModelHeader,
+  created: 'now',
   model_serialized: {
     id: '0',
     reactions: [],
     metabolites: [],
     genes: [],
   },
-  organism_id: 'asd',
   default_biomass_reaction: 'bar',
 };
 
@@ -74,13 +78,15 @@ describe('interactiveMapReducer', () => {
 
   it('should add a new card', () => {
     const actions = [
-      new fromActions.SetModel(testModel),
+      new fromActions.SetModel(testModelHeader),
+      new fromActions.SetFullModel(testModel),
       testAddCard(types.CardType.WildType),
     ];
 
     expect(applyActions(actions))
       .toEqual({
         ...initialState,
+        selectedModelHeader: testModelHeader,
         selectedModel: testModel,
         selectedCardId: '0',
         cards: {
@@ -104,7 +110,8 @@ describe('interactiveMapReducer', () => {
 
   it('should delete card', () => {
     const actions = [
-      new fromActions.SetModel(testModel),
+      new fromActions.SetModel(testModelHeader),
+      new fromActions.SetFullModel(testModel),
       testAddCard(types.CardType.WildType),
       testAddCard(types.CardType.WildType),
       new fromActions.DeleteCard('0'),
@@ -124,7 +131,8 @@ describe('interactiveMapReducer', () => {
     };
 
     const actions = [
-      new fromActions.SetModel(testModel),
+      new fromActions.SetModel(testModelHeader),
+      new fromActions.SetFullModel(testModel),
       testAddCard(types.CardType.WildType),
       new fromActions.ReactionOperationApply(operationPayload),
     ];
@@ -136,7 +144,8 @@ describe('interactiveMapReducer', () => {
 
   it('should remove the added reaction', () => {
     const actions = [
-      new fromActions.SetModel(testModel),
+      new fromActions.SetModel(testModelHeader),
+      new fromActions.SetFullModel(testModel),
       testAddCard(types.CardType.WildType),
       new fromActions.ReactionOperationApply({
         item: {

--- a/src/app/app-interactive-map/store/interactive-map.reducers.ts
+++ b/src/app/app-interactive-map/store/interactive-map.reducers.ts
@@ -41,6 +41,7 @@ export interface InteractiveMapState {
   selectedSpecies: Species;
   modelHeaders: DeCaF.ModelHeader[];
   selectedModelHeader: DeCaF.ModelHeader;
+  selectedModel: DeCaF.Model;
   maps: MapItem[];
   selectedMap: MapItem;
   mapData: PathwayMap;
@@ -69,6 +70,7 @@ export const initialState: InteractiveMapState = {
   selectedSpecies: null,
   modelHeaders: [],
   selectedModelHeader: null,
+  selectedModel: null,
   maps: [],
   selectedMap: null,
   mapData: null,
@@ -136,6 +138,11 @@ export function interactiveMapReducer(
         ...state,
         selectedModelHeader: action.payload,
       };
+    case fromInteractiveMapActions.SET_FULL_MODEL:
+      return {
+        ...state,
+        selectedModel: action.payload,
+      };
     case fromInteractiveMapActions.SET_MAPS:
       return {
         ...state,
@@ -174,8 +181,7 @@ export function interactiveMapReducer(
       switch (type) {
         case CardType.WildType: {
           name = 'Wild Type';
-          // TODO
-          // model = state.selectedModelHeader.model_serialized;
+          model = state.selectedModel.model_serialized;
           break;
         }
         case CardType.DataDriven: {

--- a/src/app/app-interactive-map/store/interactive-map.reducers.ts
+++ b/src/app/app-interactive-map/store/interactive-map.reducers.ts
@@ -39,8 +39,8 @@ export interface InteractiveMapState {
   selectedCardId: string;
   allSpecies: Species[];
   selectedSpecies: Species;
-  models: DeCaF.Model[];
-  selectedModel: DeCaF.Model;
+  modelHeaders: DeCaF.ModelHeader[];
+  selectedModelHeader: DeCaF.ModelHeader;
   maps: MapItem[];
   selectedMap: MapItem;
   mapData: PathwayMap;
@@ -67,8 +67,8 @@ export const initialState: InteractiveMapState = {
   selectedCardId: '0',
   allSpecies: [],
   selectedSpecies: null,
-  models: [],
-  selectedModel: null,
+  modelHeaders: [],
+  selectedModelHeader: null,
   maps: [],
   selectedMap: null,
   mapData: null,
@@ -129,12 +129,12 @@ export function interactiveMapReducer(
     case fromInteractiveMapActions.SET_MODELS:
       return {
         ...state,
-        models: action.payload,
+        modelHeaders: action.payload,
       };
     case fromInteractiveMapActions.SET_MODEL:
       return {
         ...state,
-        selectedModel: action.payload,
+        selectedModelHeader: action.payload,
       };
     case fromInteractiveMapActions.SET_MAPS:
       return {
@@ -174,7 +174,8 @@ export function interactiveMapReducer(
       switch (type) {
         case CardType.WildType: {
           name = 'Wild Type';
-          model = state.selectedModel.model_serialized;
+          // TODO
+          // model = state.selectedModelHeader.model_serialized;
           break;
         }
         case CardType.DataDriven: {

--- a/src/app/app-interactive-map/store/interactive-map.selectors.ts
+++ b/src/app/app-interactive-map/store/interactive-map.selectors.ts
@@ -44,12 +44,12 @@ export const getSelectedCard = createSelector(
 
 export const mapItemsByModel = createSelector(
   (state: AppState) => state.interactiveMap.maps,
-  (state: AppState) => state.interactiveMap.selectedModel,
-  (mapItems, selectedModel) => {
+  (state: AppState) => state.interactiveMap.selectedModelHeader,
+  (mapItems, selectedModelHeader) => {
     // Project the map
     const modelIds = firstIfContains(
       unique(mapItems.map(({model}) => model)),
-      selectedModel,
+      selectedModelHeader,
     );
 
     const mapsByModelId = mapItems.reduce(
@@ -69,7 +69,7 @@ export const mapItemsByModel = createSelector(
 );
 
 export const activeModels = createSelector(
-  (state: AppState) => state.interactiveMap.models,
+  (state: AppState) => state.interactiveMap.modelHeaders,
   (state: AppState) => state.interactiveMap.selectedSpecies,
   (models, selectedSpecies) => models
     .filter((m) => m.organism_id === selectedSpecies.id.toString()),

--- a/src/app/app-interactive-map/types.ts
+++ b/src/app/app-interactive-map/types.ts
@@ -191,21 +191,23 @@ export declare namespace DeCaF {
     data?: Cobra.Reaction; // included if operation is 'add' or 'modify'
   }
 
-  export interface Model {
+  export interface ModelHeader {
+    id: number;
+    project_id?: number;
+    name: string;
+    organism_id: string;
+  }
+
+  export interface Model extends ModelHeader {
     created: string;
     updated?: string;
-    id: number;
-    name: string;
     model_serialized: Cobra.Model;
-    organism_id: string;
-    project_id?: number;
     default_biomass_reaction: string;
   }
 }
 
 export interface SimulateRequest {
-  model: Cobra.Model;
-  biomass_reaction: string;
+  model_id: number;
   method: Methods;
   objective?: string;
   objective_direction: ObjectiveDirection;

--- a/src/app/services/model.service.ts
+++ b/src/app/services/model.service.ts
@@ -30,7 +30,7 @@ export class ModelService {
     return this.http.get<Cobra.Model>(`${environment.apis.model}/models/${modelId}`);
   }
 
-  loadModels(): Observable <types.DeCaF.Model[]> {
-    return this.http.get<types.DeCaF.Model[]>(`${environment.apis.model_warehouse}/models`);
+  loadModels(): Observable <types.DeCaF.ModelHeader[]> {
+    return this.http.get<types.DeCaF.ModelHeader[]>(`${environment.apis.model_warehouse}/models`);
   }
 }


### PR DESCRIPTION
- Only headers are retrieved from the model-warehouse API
- On model select, the full model is retrieved because it is needed by:
  - Escher (loaded with `builder.load_model`).
  - Displaying original bounds in the map controls

I'd like to find a way to avoid storing the full model in the store, but the two points above must be dealt with first.

![image](https://user-images.githubusercontent.com/64745/46420369-2d780c80-c730-11e8-9cb1-9a3d37203247.png)

Note: there seems to be an issue that the fluxes are not redrawn after changing the model and running a new simulation.
