### PR TITLE
refactor: change organism/species id to number

### DIFF
--- a/src/app/app-design-tool/store/design-tool.effects.ts
+++ b/src/app/app-design-tool/store/design-tool.effects.ts
@@ -65,7 +65,7 @@ export class DesignToolEffects {
   ).pipe(
     map(([a, {payload: {id: selectedOrgId}}, {payload: models}]: [never, fromActions.SetSelectedSpeciesDesign, fromActions.SetModelsDesign]) => {
       const selectedModel = models
-        .filter((model) => model.organism_id === selectedOrgId.toString())[0];
+        .filter((model) => model.organism_id === selectedOrgId)[0];
       return new fromActions.SetModelDesign(selectedModel);
     }),
   );

--- a/src/app/app-design-tool/store/design-tool.selectors.ts
+++ b/src/app/app-design-tool/store/design-tool.selectors.ts
@@ -20,5 +20,5 @@ export const activeModels = createSelector(
   (state: AppState) => state.designTool.models,
   (state: AppState) => state.designTool.selectedSpecies,
   (models, selectedSpecies) => models
-    .filter((m) => m.organism_id === selectedSpecies.id.toString()),
+    .filter((m) => m.organism_id === selectedSpecies.id),
 );

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -73,7 +73,7 @@ export class InteractiveMapEffects {
   ).pipe(
     map(([{payload: {id: selectedOrgId}}, {payload: models}]: [fromActions.SetSelectedSpecies, fromActions.SetModels]) => {
       const selectedModelHeader = models
-        .filter((model) => model.organism_id === selectedOrgId.toString())[0];
+        .filter((model) => model.organism_id === selectedOrgId)[0];
       return new fromActions.SetModel(selectedModelHeader);
     }),
   );

--- a/src/app/app-interactive-map/store/interactive-map.reducer.spec.ts
+++ b/src/app/app-interactive-map/store/interactive-map.reducer.spec.ts
@@ -38,7 +38,7 @@ const addedReaction: types.AddedReaction = {
 const testModelHeader: types.DeCaF.ModelHeader = {
   id: 0,
   name: 'Foo',
-  organism_id: 'asd',
+  organism_id: 1,
 };
 
 const testModel: types.DeCaF.Model = {

--- a/src/app/app-interactive-map/store/interactive-map.selectors.ts
+++ b/src/app/app-interactive-map/store/interactive-map.selectors.ts
@@ -72,5 +72,5 @@ export const activeModels = createSelector(
   (state: AppState) => state.interactiveMap.modelHeaders,
   (state: AppState) => state.interactiveMap.selectedSpecies,
   (models, selectedSpecies) => models
-    .filter((m) => selectedSpecies && (m.organism_id === selectedSpecies.id.toString())),
+    .filter((m) => selectedSpecies && (m.organism_id === selectedSpecies.id)),
 );

--- a/src/app/app-interactive-map/types.ts
+++ b/src/app/app-interactive-map/types.ts
@@ -195,7 +195,7 @@ export declare namespace DeCaF {
     id: number;
     project_id?: number;
     name: string;
-    organism_id: string;
+    organism_id: number;
   }
 
   export interface Model extends ModelHeader {
@@ -255,7 +255,7 @@ export interface AddedReaction extends BiggReaction {
 
 export interface Species {
   project_id: string;
-  id: string;
+  id: number;
   name: string;
   created: string;
   updated: string;


### PR DESCRIPTION
Based on the work in https://github.com/DD-DeCaF/model-warehouse/pull/5 the organism_id in the model-warehouse is changed from string type to integer.

I'm not actually sure if this matters, though, or if the frontend handles all identifiers as string. I need some help to finish this I think.