### PR TITLE
Log user out if refresh request fails

### DIFF
--- a/src/app/session/session.service.ts
+++ b/src/app/session/session.service.ts
@@ -102,6 +102,7 @@ export class SessionService {
       localStorage.setItem(AUTHORIZATION_TOKEN, token);
     }, () => {
       console.log('Session: Token refresh failure');
+      this.logout();
     });
 
     return refresh$;


### PR DESCRIPTION
Quickfix to simply log out. There is no feedback to the user, but they will at least be logged out instead of keeping an invalid refresh token and resending it for each api request.