### PR TITLE
fix: disable the design button to prevent spamming design creation

### DIFF
--- a/src/app/app-design-tool/components/app-form-design/app-form-design.component.html
+++ b/src/app/app-design-tool/components/app-form-design/app-form-design.component.html
@@ -102,7 +102,6 @@
       class="design-button"
       type="submit"
       color="primary"
-      (click)="formSubmitted()"
       [disabled]="(!designForm.valid || buttonClicked)"
       #design>DESIGN
     </button>

--- a/src/app/app-design-tool/components/app-form-design/app-form-design.component.html
+++ b/src/app/app-design-tool/components/app-form-design/app-form-design.component.html
@@ -102,7 +102,8 @@
       class="design-button"
       type="submit"
       color="primary"
-      [disabled]="!designForm.valid"
+      (click)="formSubmitted()"
+      [disabled]="(!designForm.valid || buttonClicked)"
       #design>DESIGN
     </button>
   </form>

--- a/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
+++ b/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
@@ -146,6 +146,7 @@ export class AppFormDesignComponent implements OnInit, AfterViewInit {
   }
 
   onSubmit(): void {
+    this.buttonClicked = !this.buttonClicked;
     this.store.dispatch(new StartDesign(this.designForm.value));
   }
 
@@ -184,9 +185,5 @@ export class AppFormDesignComponent implements OnInit, AfterViewInit {
     this.designForm.patchValue({
       project_id: '',
     });
-  }
-
-  formSubmitted(): void {
-    this.buttonClicked = !this.buttonClicked;
   }
 }

--- a/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
+++ b/src/app/app-design-tool/components/app-form-design/app-form-design.component.ts
@@ -42,6 +42,7 @@ import {IamService} from '../../../services/iam.service';
 })
 export class AppFormDesignComponent implements OnInit, AfterViewInit {
   designForm: FormGroup;
+  buttonClicked = false;
   @ViewChild('species') speciesSelector: MatSelect;
   @ViewChild('auto') productSelector: MatAutocomplete;
   @ViewChild('projects') projectSelector: MatSelect;
@@ -111,6 +112,9 @@ export class AppFormDesignComponent implements OnInit, AfterViewInit {
       .pipe(
         debounceTime(300),
         switchMap((value) => this.warehouseService.getProducts(value)));
+
+    this.designForm.valueChanges
+      .subscribe(() => this.buttonClicked = false);
   }
 
   ngAfterViewInit(): void {
@@ -180,5 +184,9 @@ export class AppFormDesignComponent implements OnInit, AfterViewInit {
     this.designForm.patchValue({
       project_id: '',
     });
+  }
+
+  formSubmitted(): void {
+    this.buttonClicked = !this.buttonClicked;
   }
 }


### PR DESCRIPTION
When a job cannot be created immediately users could spam the 'DESIGN' button to spawn additional duplicate designs (possibly unintentionally). I've added a quick fix by disabling the design button right after submission until a user manipulates the form again.