### PR TITLE
fix: correct processing of added reactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -450,7 +450,6 @@
       "integrity": "sha512-tftSoN4hlEZIJuhzCHbZB7CXzu2KrK1ftcikrXlHUgqs2zOUjPXyQFgrV4tT0BD02kePQcyPnlbDbXqZt/Taag==",
       "requires": {
         "baconjs": "^0.7.71",
-        "d3-brush": "git+https://github.com/zakandrewking/d3-brush.git#0def381d33b6de58383c6f8df68f042b690df416",
         "d3-drag": "^1.0.2",
         "d3-dsv": "^1.0.3",
         "d3-request": "^1.0.3",
@@ -466,6 +465,17 @@
         "vkbeautify": "^0.99.1"
       },
       "dependencies": {
+        "d3-brush": {
+          "version": "git+https://github.com/zakandrewking/d3-brush.git#0def381d33b6de58383c6f8df68f042b690df416",
+          "from": "git+https://github.com/zakandrewking/d3-brush.git#0def381d33b6de58383c6f8df68f042b690df416",
+          "requires": {
+            "d3-dispatch": "1",
+            "d3-drag": "1",
+            "d3-interpolate": "1",
+            "d3-selection": "1",
+            "d3-transition": "1"
+          }
+        },
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -2764,17 +2774,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "d3-brush": {
-      "version": "git+https://github.com/zakandrewking/d3-brush.git#0def381d33b6de58383c6f8df68f042b690df416",
-      "from": "git+https://github.com/zakandrewking/d3-brush.git",
-      "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
     },
     "d3-collection": {
       "version": "1.0.7",
@@ -7091,6 +7090,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
       "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -7100,7 +7100,8 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/app/app-interactive-map/store/interactive-map.effects.ts
+++ b/src/app/app-interactive-map/store/interactive-map.effects.ts
@@ -217,7 +217,7 @@ export class InteractiveMapEffects {
               method: 'pfba',
               objective: null,
               objective_direction: null,
-              operations: this.ninjaService.getOperations(pathwayPrediction, reactions),
+              operations: this.ninjaService.getOperations(pathwayPrediction),
             };
             return this.simulationService.simulate(payloadSimulate);
           }),


### PR DESCRIPTION
1. Use info about metabolites and added reactions from the response
2. If id-mapper returns more that one mapped bigg id, use the one that is in the model (otherwise use the first one)
3. Add only those metabolites that are not in the model